### PR TITLE
Fixing list type when using max_features param in plot()

### DIFF
--- a/sage/plotting.py
+++ b/sage/plotting.py
@@ -68,7 +68,7 @@ def plot(explanation,
                          + ['Remaining Features'])
         values = (list(values[:max_features])
                   + [np.sum(values[max_features:])])
-        std = (list(std[:max_features])
+        std = np.array(list(std[:max_features])
                + [np.sum(std[max_features:] ** 2) ** 0.5])
 
     # Warn if too many features.


### PR DESCRIPTION
When calling `plot()` with the `max_features` parameter, it crashes with the following error: 

```
TypeError                                 Traceback (most recent call last)
script.py()
----> 1 sage.plot(sage_values, feature_names=list(X_test.columns), max_features=20)

File c:\<redacted>\Anaconda3\envs\lumc\lib\site-packages\sage\plotting.py:85, in plot(explanation, feature_names, sort_features, max_features, orientation, error_bars, confidence_level, capsize, color, title, title_size, tick_size, tick_rotation, label_size, figsize, return_fig)
     83 else:
     84     assert 0 < confidence_level < 1
---> 85     std = std * norm.ppf(0.5 + confidence_level / 2)
     87 # Make plot.
     88 fig = plt.figure(figsize=figsize)

TypeError: can't multiply sequence by non-int of type 'numpy.float64'
```

This change casts the `std` variable as `np.array` when `max_features` is set, to fix this issue.