### PR TITLE
Add basic support for linting / format🐍

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,10 @@ repos:
       - id: debug-statements
       - id: end-of-file-fixer
       - id: mixed-line-ending
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.2.1
+    hooks:
+    - id: ruff
+      args:
+      - --fix
+    - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
 dev=[
     "build",
     "pre-commit",
+    "ruff"
 ]
 
 notebook=[
@@ -54,3 +55,33 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 packages = ["sage"]
+
+[tool.ruff]
+
+
+include = ["*.py", "*.pyi", "**/pyproject.toml", "*.ipynb"]
+
+
+[tool.ruff.lint]
+
+# See rules: https://beta.ruff.rs/docs/rules/
+select = [
+    "I",    # isort
+    "N",    # pep8-naming
+    "NPY",  # numpy
+    "RUF",  # ruff-specific rules
+]
+
+ignore = [
+    "N803",  # argument name should be lowercase; fine for matrices
+    "N806",  # variable name should be lowercase; fine for matrices
+]
+
+preview = true
+
+[tool.ruff.format]
+preview = true
+
+[tool.ruff.lint.isort]
+known-first-party = ["sage"]
+section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ select = [
 ignore = [
     "N803",  # argument name should be lowercase; fine for matrices
     "N806",  # variable name should be lowercase; fine for matrices
+    "NPY002", # allow calls to np.random; could cause slightly different results
 ]
 
 preview = true

--- a/sage/__init__.py
+++ b/sage/__init__.py
@@ -1,9 +1,10 @@
-from sage import utils, core, imputers, grouped_imputers, plotting, datasets
+from sage import core, datasets, grouped_imputers, imputers, plotting, utils
+
 from .core import Explanation, load
-from .plotting import plot, comparison_plot
-from .imputers import DefaultImputer, MarginalImputer
 from .grouped_imputers import GroupedDefaultImputer, GroupedMarginalImputer
-from .permutation_estimator import PermutationEstimator
+from .imputers import DefaultImputer, MarginalImputer
 from .iterated_estimator import IteratedEstimator
 from .kernel_estimator import KernelEstimator
+from .permutation_estimator import PermutationEstimator
+from .plotting import comparison_plot, plot
 from .sign_estimator import SignEstimator

--- a/sage/core.py
+++ b/sage/core.py
@@ -1,40 +1,44 @@
 import pickle
+
 import numpy as np
+
 from sage import plotting
 
 
 class Explanation:
-    '''
+    """
     For storing and plotting Explanations.
-    
+
     Args:
       values: explanation values.
       std: standard deviation confidence intervals for explanation values.
       explanation_type: 'SAGE' or 'Shapley Effects' (used only for plotting).
-    '''
+    """
 
-    def __init__(self, values, std, explanation_type='SAGE'):
+    def __init__(self, values, std, explanation_type="SAGE"):
         self.values = values
         self.std = std
         self.explanation_type = explanation_type
 
-    def plot(self,
-             feature_names=None,
-             sort_features=True,
-             max_features=np.inf,
-             orientation='horizontal',
-             error_bars=True,
-             confidence_level=0.95,
-             capsize=5,
-             color='tab:green',
-             title='Feature Importance',
-             title_size=20,
-             tick_size=16,
-             tick_rotation=None,
-             label_size=16,
-             figsize=(10, 7),
-             return_fig=False):
-        '''
+    def plot(
+        self,
+        feature_names=None,
+        sort_features=True,
+        max_features=np.inf,
+        orientation="horizontal",
+        error_bars=True,
+        confidence_level=0.95,
+        capsize=5,
+        color="tab:green",
+        title="Feature Importance",
+        title_size=20,
+        tick_size=16,
+        tick_rotation=None,
+        label_size=16,
+        figsize=(10, 7),
+        return_fig=False,
+    ):
+        """
         Plot SAGE values.
 
         Args:
@@ -53,32 +57,48 @@ class Explanation:
           label_size: font size for label.
           figsize: figure size (if fig is None).
           return_fig: whether to return matplotlib figure object.
-        '''
+        """
         return plotting.plot(
-            self, feature_names, sort_features, max_features, orientation,
-            error_bars, confidence_level, capsize, color, title, title_size,
-            tick_size, tick_rotation, label_size, figsize, return_fig)
+            self,
+            feature_names,
+            sort_features,
+            max_features,
+            orientation,
+            error_bars,
+            confidence_level,
+            capsize,
+            color,
+            title,
+            title_size,
+            tick_size,
+            tick_rotation,
+            label_size,
+            figsize,
+            return_fig,
+        )
 
-    def comparison(self,
-                   other_values,
-                   comparison_names=None,
-                   feature_names=None,
-                   sort_features=True,
-                   max_features=np.inf,
-                   orientation='vertical',
-                   error_bars=True,
-                   confidence_level=0.95,
-                   capsize=5,
-                   colors=None,
-                   title='Feature Importance Comparison',
-                   title_size=20,
-                   tick_size=16,
-                   tick_rotation=None,
-                   label_size=16,
-                   legend_loc=None,
-                   figsize=(10, 7),
-                   return_fig=False):
-        '''
+    def comparison(
+        self,
+        other_values,
+        comparison_names=None,
+        feature_names=None,
+        sort_features=True,
+        max_features=np.inf,
+        orientation="vertical",
+        error_bars=True,
+        confidence_level=0.95,
+        capsize=5,
+        colors=None,
+        title="Feature Importance Comparison",
+        title_size=20,
+        tick_size=16,
+        tick_rotation=None,
+        label_size=16,
+        legend_loc=None,
+        figsize=(10, 7),
+        return_fig=False,
+    ):
+        """
         Plot comparison with another set of SAGE values.
 
         Args:
@@ -100,28 +120,45 @@ class Explanation:
           legend_loc: legend location.
           figsize: figure size (if fig is None).
           return_fig: whether to return matplotlib figure object.
-        '''
+        """
         return plotting.comparison_plot(
-            (self, other_values), comparison_names, feature_names,
-            sort_features, max_features, orientation, error_bars,
-            confidence_level, capsize, colors, title, title_size, tick_size,
-            tick_rotation, label_size, legend_loc, figsize, return_fig)
+            (self, other_values),
+            comparison_names,
+            feature_names,
+            sort_features,
+            max_features,
+            orientation,
+            error_bars,
+            confidence_level,
+            capsize,
+            colors,
+            title,
+            title_size,
+            tick_size,
+            tick_rotation,
+            label_size,
+            legend_loc,
+            figsize,
+            return_fig,
+        )
 
-    def plot_sign(self,
-                  feature_names,
-                  sort_features=True,
-                  max_features=np.inf,
-                  orientation='horizontal',
-                  confidence_level=0.95,
-                  capsize=5,
-                  title='Feature Importance Sign',
-                  title_size=20,
-                  tick_size=16,
-                  tick_rotation=None,
-                  label_size=16,
-                  figsize=(10, 7),
-                  return_fig=False):
-        '''
+    def plot_sign(
+        self,
+        feature_names,
+        sort_features=True,
+        max_features=np.inf,
+        orientation="horizontal",
+        confidence_level=0.95,
+        capsize=5,
+        title="Feature Importance Sign",
+        title_size=20,
+        tick_size=16,
+        tick_rotation=None,
+        label_size=16,
+        figsize=(10, 7),
+        return_fig=False,
+    ):
+        """
         Plot SAGE values, focusing on their sign.
 
         Args:
@@ -138,31 +175,44 @@ class Explanation:
           label_size: font size for label.
           figsize: figure size (if fig is None).
           return_fig: whether to return matplotlib figure object.
-        '''
+        """
         return plotting.plot_sign(
-            self, feature_names, sort_features, max_features, orientation,
-            confidence_level, capsize, title, title_size, tick_size,
-            tick_rotation, label_size, figsize, return_fig)
+            self,
+            feature_names,
+            sort_features,
+            max_features,
+            orientation,
+            confidence_level,
+            capsize,
+            title,
+            title_size,
+            tick_size,
+            tick_rotation,
+            label_size,
+            figsize,
+            return_fig,
+        )
 
     def save(self, filename):
-        '''Save Explanation object.'''
+        """Save Explanation object."""
         if isinstance(filename, str):
-            with open(filename, 'wb') as f:
+            with open(filename, "wb") as f:
                 pickle.dump(self, f)
         else:
-            raise TypeError('filename must be str')
+            raise TypeError("filename must be str")
 
     def __repr__(self):
-        with np.printoptions(precision=2, threshold=12, floatmode='fixed'):
-            return '{} Explanation(\n  (Mean): {}\n  (Std):  {}\n)'.format(
-                self.explanation_type, self.values, self.std)
+        with np.printoptions(precision=2, threshold=12, floatmode="fixed"):
+            return "{} Explanation(\n  (Mean): {}\n  (Std):  {}\n)".format(
+                self.explanation_type, self.values, self.std
+            )
 
 
 def load(filename):
-    '''Load Explanation object.'''
-    with open(filename, 'rb') as f:
+    """Load Explanation object."""
+    with open(filename, "rb") as f:
         sage_values = pickle.load(f)
         if isinstance(sage_values, Explanation):
             return sage_values
         else:
-            raise ValueError('object is not instance of Explanation class')
+            raise ValueError("object is not instance of Explanation class")

--- a/sage/datasets.py
+++ b/sage/datasets.py
@@ -1,83 +1,115 @@
 import os
+
 import pandas as pd
 
-github_data_url = 'https://github.com/iancovert/sage/raw/master/data/'
+github_data_url = "https://github.com/iancovert/sage/raw/master/data/"
 
 
 def airbnb():
-    '''
+    """
     Airbnb listing data from Kaggle.
 
     Located at: https://www.kaggle.com/dgomonov/new-york-city-airbnb-open-data
-    '''
-    path = os.path.join(github_data_url, 'AB_NYC_2019.csv')
-    df = pd.read_table(path, sep=',', header=0, index_col=None)
+    """
+    path = os.path.join(github_data_url, "AB_NYC_2019.csv")
+    df = pd.read_table(path, sep=",", header=0, index_col=None)
 
     # Type conversions
-    df['name'] = df['name'].astype(str)
-    df['host_name'] = df['host_name'].astype(str)
-    df['last_review'] = pd.to_datetime(df['last_review'])
+    df["name"] = df["name"].astype(str)
+    df["host_name"] = df["host_name"].astype(str)
+    df["last_review"] = pd.to_datetime(df["last_review"])
     return df
 
 
 def bank():
-    '''
+    """
     Bank marketing data from UCI dataset repository.
 
     Located at: https://archive.ics.uci.edu/ml/datasets/bank+marketing
-    '''
+    """
     columns = [
-        'Age', 'Job', 'Marital', 'Education', 'Default', 'Balance', 'Housing',
-        'Loan', 'Contact', 'Day', 'Month', 'Duration', 'Campaign', 'Prev Days',
-        'Prev Contacts', 'Prev Outcome', 'Success']
-    path = os.path.join(github_data_url, 'bank-full.csv')
-    df = pd.read_table(path, sep=';', header=None, index_col=None, skiprows=1,
-                       names=columns)
+        "Age",
+        "Job",
+        "Marital",
+        "Education",
+        "Default",
+        "Balance",
+        "Housing",
+        "Loan",
+        "Contact",
+        "Day",
+        "Month",
+        "Duration",
+        "Campaign",
+        "Prev Days",
+        "Prev Contacts",
+        "Prev Outcome",
+        "Success",
+    ]
+    path = os.path.join(github_data_url, "bank-full.csv")
+    df = pd.read_table(
+        path, sep=";", header=None, index_col=None, skiprows=1, names=columns
+    )
 
     # Convert label.
-    df['Success'] = (df['Success'] == 'yes')
+    df["Success"] = df["Success"] == "yes"
     return df
 
 
 def bike():
-    '''
+    """
     Bike sharing dataset from Kaggle competition.
 
     Located at: https://www.kaggle.com/c/bike-sharing-demand
-    '''
-    path = os.path.join(github_data_url, 'bike.csv')
-    df = pd.read_table(path, sep=',', header=0, index_col=None)
+    """
+    path = os.path.join(github_data_url, "bike.csv")
+    df = pd.read_table(path, sep=",", header=0, index_col=None)
     columns = df.columns.tolist()
 
     # Split and remove datetime column.
-    df['datetime'] = pd.to_datetime(df['datetime'])
-    df['year'] = df['datetime'].dt.year
-    df['month'] = df['datetime'].dt.month
-    df['day'] = df['datetime'].dt.day
-    df['hour'] = df['datetime'].dt.hour
-    df = df.drop('datetime', axis=1)
+    df["datetime"] = pd.to_datetime(df["datetime"])
+    df["year"] = df["datetime"].dt.year
+    df["month"] = df["datetime"].dt.month
+    df["day"] = df["datetime"].dt.day
+    df["hour"] = df["datetime"].dt.hour
+    df = df.drop("datetime", axis=1)
 
     # Reorder and rename columns.
-    df = df[['year', 'month', 'day', 'hour'] + columns[1:]]
+    df = df[["year", "month", "day", "hour"] + columns[1:]]
     df.columns = list(map(str.title, df.columns))
     return df
 
 
 def credit():
-    '''
+    """
     German credit quality dataset from UCI dataset repository.
 
     Located at: https://archive.ics.uci.edu/ml/datasets/South+German+Credit+%28UPDATE%29
-    '''
+    """
     columns = [
-        'Checking Status', 'Duration', 'Credit History', 'Purpose',
-        'Credit Amount', 'Savings Account/Bonds', 'Employment Since',
-        'Installment Rate', 'Personal Status', 'Debtors/Guarantors',
-        'Residence Duration', 'Property Type', 'Age',
-        'Other Installment Plans', 'Housing Ownership',
-        'Number Existing Credits', 'Job', 'Number Liable', 'Telephone',
-        'Foreign Worker', 'Good Customer'
+        "Checking Status",
+        "Duration",
+        "Credit History",
+        "Purpose",
+        "Credit Amount",
+        "Savings Account/Bonds",
+        "Employment Since",
+        "Installment Rate",
+        "Personal Status",
+        "Debtors/Guarantors",
+        "Residence Duration",
+        "Property Type",
+        "Age",
+        "Other Installment Plans",
+        "Housing Ownership",
+        "Number Existing Credits",
+        "Job",
+        "Number Liable",
+        "Telephone",
+        "Foreign Worker",
+        "Good Customer",
     ]
-    path = os.path.join(github_data_url, 'SouthGermanCredit.asc')
-    return pd.read_table(path, sep=' ', header=None, index_col=None,
-                         names=columns, skiprows=1)
+    path = os.path.join(github_data_url, "SouthGermanCredit.asc")
+    return pd.read_table(
+        path, sep=" ", header=None, index_col=None, names=columns, skiprows=1
+    )

--- a/sage/imputers.py
+++ b/sage/imputers.py
@@ -1,10 +1,13 @@
-import numpy as np
 import warnings
+
+import numpy as np
+
 from sage import utils
 
 
 class Imputer:
-    '''Imputer base class.'''
+    """Imputer base class."""
+
     def __init__(self, model):
         self.model = utils.model_conversion(model)
 
@@ -13,13 +16,14 @@ class Imputer:
 
 
 class DefaultImputer(Imputer):
-    '''Replace features with default values.'''
+    """Replace features with default values."""
+
     def __init__(self, model, values):
         super().__init__(model)
         if values.ndim == 1:
             values = values[np.newaxis]
         elif values[0] != 1:
-            raise ValueError('values shape must be (dim,) or (1, dim)')
+            raise ValueError("values shape must be (dim,) or (1, dim)")
         self.values = values
         self.values_repeat = values
         self.num_groups = values.shape[1]
@@ -38,7 +42,8 @@ class DefaultImputer(Imputer):
 
 
 class MarginalImputer(Imputer):
-    '''Marginalizing out removed features with their marginal distribution.'''
+    """Marginalizing out removed features with their marginal distribution."""
+
     def __init__(self, model, data):
         super().__init__(model)
         self.data = data
@@ -47,9 +52,11 @@ class MarginalImputer(Imputer):
         self.num_groups = data.shape[1]
 
         if len(data) > 1024:
-            warnings.warn('using {} background samples may lead to slow '
-                          'runtime, consider using <= 1024'.format(
-                            len(data)), RuntimeWarning)
+            warnings.warn(
+                f"using {len(data)} background samples may lead to slow "
+                "runtime, consider using <= 1024",
+                RuntimeWarning,
+            )
 
     def __call__(self, x, S):
         # Prepare x and S.

--- a/sage/iterated_estimator.py
+++ b/sage/iterated_estimator.py
@@ -164,13 +164,11 @@ class IteratedEstimator:
 
         # Iterated sampling.
         tracker_list = []
-        rng = np.random.default_rng(seed=42)
-
         for i, ind in enumerate(ordering):
             tracker = utils.ImportanceTracker()
             for it in range(n_loops):
                 # Sample data.
-                mb = rng.choice(N, batch_size)
+                mb = np.random.choice(N, batch_size)
                 x = X[mb]
                 y = Y[mb]
 
@@ -206,7 +204,7 @@ class IteratedEstimator:
                             f"StdDev Ratio = {ratio:.4f} " f"(Converge at {thresh:.4f})"
                         )
                     else:
-                        print(f"StdDev Ratio = {ratio:.4f}")
+                        print("StdDev Ratio = {:.4f}".format(ratio))
 
                 # Check for convergence.
                 if detect_convergence:

--- a/sage/iterated_estimator.py
+++ b/sage/iterated_estimator.py
@@ -1,17 +1,18 @@
 import numpy as np
-from sage import utils, core
 from tqdm.auto import tqdm
+
+from sage import core, utils
 
 
 def estimate_total(imputer, X, Y, batch_size, loss_fn):
-    '''Estimate sum of SAGE values.'''
+    """Estimate sum of SAGE values."""
     N = 0
     mean_loss = 0
     marginal_loss = 0
     num_features = imputer.num_groups
     for i in range(np.ceil(len(X) / batch_size).astype(int)):
-        x = X[i * batch_size:(i + 1) * batch_size]
-        y = Y[i * batch_size:(i + 1) * batch_size]
+        x = X[i * batch_size : (i + 1) * batch_size]
+        y = Y[i * batch_size : (i + 1) * batch_size]
         N += len(x)
 
         # All features.
@@ -28,7 +29,7 @@ def estimate_total(imputer, X, Y, batch_size, loss_fn):
 
 
 def estimate_holdout_importance(imputer, X, Y, batch_size, loss_fn, batches, rng):
-    '''Estimate the impact of holding out features individually.'''
+    """Estimate the impact of holding out features individually."""
     N, _ = X.shape
     num_features = imputer.num_groups
     all_loss = 0
@@ -48,44 +49,43 @@ def estimate_holdout_importance(imputer, X, Y, batch_size, loss_fn, batches, rng
         # Loss with features held out.
         for i in range(num_features):
             S[:, i] = 0
-            holdout_importance[i] += (
-                np.sum(loss_fn(imputer(x, S), y) - holdout_importance[i])
-                / (it + 1))
+            holdout_importance[i] += np.sum(
+                loss_fn(imputer(x, S), y) - holdout_importance[i]
+            ) / (it + 1)
             S[:, i] = 1
 
     return holdout_importance - all_loss
 
 
 class IteratedEstimator:
-    '''
+    """
     Estimate SAGE values one at a time by sampling subsets of features.
 
     Args:
       imputer: model that accommodates held out features.
       loss: loss function ('mse', 'cross entropy', 'zero one').
       random_state: random seed, enables reproducibility.
-    '''
+    """
 
-    def __init__(self,
-                 imputer,
-                 loss='cross entropy',
-                 random_state=None):
+    def __init__(self, imputer, loss="cross entropy", random_state=None):
         self.imputer = imputer
-        self.loss_fn = utils.get_loss(loss, reduction='none')
+        self.loss_fn = utils.get_loss(loss, reduction="none")
         self.random_state = random_state
 
-    def __call__(self,
-                 X,
-                 Y=None,
-                 batch_size=512,
-                 detect_convergence=True,
-                 thresh=0.025,
-                 n_samples=None,
-                 optimize_ordering=True,
-                 ordering_batches=1,
-                 verbose=False,
-                 bar=True):
-        '''
+    def __call__(
+        self,
+        X,
+        Y=None,
+        batch_size=512,
+        detect_convergence=True,
+        thresh=0.025,
+        n_samples=None,
+        optimize_ordering=True,
+        ordering_batches=1,
+        verbose=False,
+        bar=True,
+    ):
+        """
         Estimate SAGE values.
 
         Args:
@@ -109,21 +109,20 @@ class IteratedEstimator:
         analyzed.
 
         Returns: Explanation object.
-        '''
+        """
         # Set random state.
         self.rng = np.random.default_rng(seed=self.random_state)
 
         # Determine explanation type.
         if Y is not None:
-            explanation_type = 'SAGE'
+            explanation_type = "SAGE"
         else:
-            explanation_type = 'Shapley Effects'
+            explanation_type = "Shapley Effects"
 
         # Verify model.
         N, _ = X.shape
         num_features = self.imputer.num_groups
-        X, Y = utils.verify_model_data(self.imputer, X, Y, self.loss_fn,
-                                       batch_size)
+        X, Y = utils.verify_model_data(self.imputer, X, Y, self.loss_fn, batch_size)
 
         # Possibly force convergence detection.
         if n_samples is None:
@@ -131,7 +130,7 @@ class IteratedEstimator:
             if not detect_convergence:
                 detect_convergence = True
                 if verbose:
-                    print('Turning convergence detection on')
+                    print("Turning convergence detection on")
 
         if detect_convergence:
             assert 0 < thresh < 1
@@ -144,12 +143,12 @@ class IteratedEstimator:
         # Feature ordering.
         if optimize_ordering:
             if verbose:
-                print('Determining feature ordering...')
+                print("Determining feature ordering...")
             holdout_importance = estimate_holdout_importance(
-                self.imputer, X, Y, batch_size, self.loss_fn, ordering_batches,
-                self.rng)
+                self.imputer, X, Y, batch_size, self.loss_fn, ordering_batches, self.rng
+            )
             if verbose:
-                print('Done')
+                print("Done")
             # Use np.abs in case there are large negative contributors.
             ordering = list(np.argsort(np.abs(holdout_importance))[::-1])
         else:
@@ -165,11 +164,13 @@ class IteratedEstimator:
 
         # Iterated sampling.
         tracker_list = []
+        rng = np.random.default_rng(seed=42)
+
         for i, ind in enumerate(ordering):
             tracker = utils.ImportanceTracker()
             for it in range(n_loops):
                 # Sample data.
-                mb = np.random.choice(N, batch_size)
+                mb = rng.choice(N, batch_size)
                 x = X[mb]
                 y = Y[mb]
 
@@ -192,30 +193,30 @@ class IteratedEstimator:
 
                 # Calculate progress.
                 std = tracker.std.item()
-                gap = (
-                    max(upper_val, tracker.values.item()) -
-                    min(lower_val, tracker.values.item()))
+                gap = max(upper_val, tracker.values.item()) - min(
+                    lower_val, tracker.values.item()
+                )
                 gap = max(gap, 1e-12)
                 ratio = std / gap
 
                 # Print progress message.
                 if verbose:
                     if detect_convergence:
-                        print(f'StdDev Ratio = {ratio:.4f} '
-                              f'(Converge at {thresh:.4f})')
+                        print(
+                            f"StdDev Ratio = {ratio:.4f} " f"(Converge at {thresh:.4f})"
+                        )
                     else:
-                        print('StdDev Ratio = {:.4f}'.format(ratio))
+                        print(f"StdDev Ratio = {ratio:.4f}")
 
                 # Check for convergence.
                 if detect_convergence:
                     if ratio < thresh:
                         if verbose:
-                            print('Detected feature convergence')
+                            print("Detected feature convergence")
 
                         # Skip bar ahead.
                         if bar:
-                            bar.n = np.around(
-                                bar.total * (i + 1) / num_features, 4)
+                            bar.n = np.around(bar.total * (i + 1) / num_features, 4)
                             bar.refresh()
                         break
 
@@ -226,7 +227,7 @@ class IteratedEstimator:
                     bar.refresh()
 
             if verbose:
-                print(f'Done with feature {i}')
+                print(f"Done with feature {i}")
             tracker_list.append(tracker)
 
             # Adjust min max value.
@@ -238,9 +239,7 @@ class IteratedEstimator:
 
         # Extract SAGE values.
         reverse_ordering = [ordering.index(ind) for ind in range(num_features)]
-        values = np.array(
-            [tracker_list[ind].values.item() for ind in reverse_ordering])
-        std = np.array(
-            [tracker_list[ind].std.item() for ind in reverse_ordering])
+        values = np.array([tracker_list[ind].values.item() for ind in reverse_ordering])
+        std = np.array([tracker_list[ind].std.item() for ind in reverse_ordering])
 
         return core.Explanation(values, std, explanation_type)

--- a/sage/kernel_estimator.py
+++ b/sage/kernel_estimator.py
@@ -4,7 +4,7 @@ from tqdm.auto import tqdm
 from sage import core, utils
 
 
-def calculate_A(num_features):  # noqa: N802
+def calculate_A(num_features):  # noqa:N802
     """Calculate A parameter's exact form."""
     p_coaccur = (
         np.sum(

--- a/sage/plotting.py
+++ b/sage/plotting.py
@@ -1,26 +1,29 @@
 import warnings
-import numpy as np
+
 import matplotlib.pyplot as plt
+import numpy as np
 from scipy.stats import norm
 
 
-def plot(explanation,
-         feature_names=None,
-         sort_features=True,
-         max_features=np.inf,
-         orientation='horizontal',
-         error_bars=True,
-         confidence_level=0.95,
-         capsize=5,
-         color='tab:green',
-         title='Feature Importance',
-         title_size=20,
-         tick_size=16,
-         tick_rotation=None,
-         label_size=16,
-         figsize=(10, 7),
-         return_fig=False):
-    '''
+def plot(
+    explanation,
+    feature_names=None,
+    sort_features=True,
+    max_features=np.inf,
+    orientation="horizontal",
+    error_bars=True,
+    confidence_level=0.95,
+    capsize=5,
+    color="tab:green",
+    title="Feature Importance",
+    title_size=20,
+    tick_size=16,
+    tick_rotation=None,
+    label_size=16,
+    figsize=(10, 7),
+    return_fig=False,
+):
+    """
     Plot SAGE values.
 
     Args:
@@ -40,11 +43,10 @@ def plot(explanation,
       label_size: font size for label.
       figsize: figure size (if fig is None).
       return_fig: whether to return matplotlib figure object.
-    '''
+    """
     # Default feature names.
     if feature_names is None:
-        feature_names = ['Feature {}'.format(i) for i in
-                         range(len(explanation.values))]
+        feature_names = [f"Feature {i}" for i in range(len(explanation.values))]
     if isinstance(feature_names, list):
         feature_names = np.array(feature_names)
 
@@ -63,18 +65,17 @@ def plot(explanation,
 
     # Remove extra features if necessary.
     if len(feature_names) > max_features:
-        feature_names = (list(feature_names[:max_features])
-                         + ['Remaining Features'])
-        values = (list(values[:max_features])
-                  + [np.sum(values[max_features:])])
-        std = (list(std[:max_features])
-               + [np.sum(std[max_features:] ** 2) ** 0.5])
+        feature_names = [*list(feature_names[:max_features]), "Remaining Features"]
+        values = [*list(values[:max_features]), np.sum(values[max_features:])]
+        std = [*list(std[:max_features]), np.sum(std[max_features:] ** 2) ** 0.5]
 
     # Warn if too many features.
     if len(feature_names) > 50:
-        warnings.warn('Plotting {} features may make figure too crowded, '
-                      'consider using max_features'.format(
-                        len(feature_names)), Warning)
+        warnings.warn(
+            "Plotting {} features may make figure too crowded, "
+            "consider using max_features".format(len(feature_names)),
+            Warning,
+        )
 
     # Discard std if necessary.
     if not error_bars:
@@ -87,54 +88,66 @@ def plot(explanation,
     fig = plt.figure(figsize=figsize)
     ax = fig.gca()
 
-    if orientation == 'horizontal':
+    if orientation == "horizontal":
         # Bar chart.
-        ax.barh(np.arange(len(feature_names))[::-1], values,
-                color=color, xerr=std, capsize=capsize)
+        ax.barh(
+            np.arange(len(feature_names))[::-1],
+            values,
+            color=color,
+            xerr=std,
+            capsize=capsize,
+        )
 
         # Feature labels.
         if tick_rotation is not None:
-            raise ValueError('rotation not supported for horizontal charts')
+            raise ValueError("rotation not supported for horizontal charts")
         ax.set_yticks(np.arange(len(feature_names))[::-1])
         ax.set_yticklabels(feature_names, fontsize=label_size)
 
         # Axis labels and ticks.
-        ax.set_ylabel('')
-        ax.set_xlabel('{} value'.format(explanation.explanation_type),
-                      fontsize=label_size)
-        ax.tick_params(axis='x', labelsize=tick_size)
+        ax.set_ylabel("")
+        ax.set_xlabel(f"{explanation.explanation_type} value", fontsize=label_size)
+        ax.tick_params(axis="x", labelsize=tick_size)
 
-    elif orientation == 'vertical':
+    elif orientation == "vertical":
         # Bar chart.
-        ax.bar(np.arange(len(feature_names)), values, color=color,
-               yerr=std, capsize=capsize)
+        ax.bar(
+            np.arange(len(feature_names)),
+            values,
+            color=color,
+            yerr=std,
+            capsize=capsize,
+        )
 
         # Feature labels.
         if tick_rotation is None:
             tick_rotation = 45
         if tick_rotation < 90:
-            ha = 'right'
-            rotation_mode = 'anchor'
+            ha = "right"
+            rotation_mode = "anchor"
         else:
-            ha = 'center'
-            rotation_mode = 'default'
+            ha = "center"
+            rotation_mode = "default"
         ax.set_xticks(np.arange(len(feature_names)))
-        ax.set_xticklabels(feature_names, rotation=tick_rotation, ha=ha,
-                           rotation_mode=rotation_mode,
-                           fontsize=label_size)
+        ax.set_xticklabels(
+            feature_names,
+            rotation=tick_rotation,
+            ha=ha,
+            rotation_mode=rotation_mode,
+            fontsize=label_size,
+        )
 
         # Axis labels and ticks.
-        ax.set_ylabel('{} value'.format(explanation.explanation_type),
-                      fontsize=label_size)
-        ax.set_xlabel('')
-        ax.tick_params(axis='y', labelsize=tick_size)
+        ax.set_ylabel(f"{explanation.explanation_type} value", fontsize=label_size)
+        ax.set_xlabel("")
+        ax.tick_params(axis="y", labelsize=tick_size)
 
     else:
-        raise ValueError('orientation must be horizontal or vertical')
+        raise ValueError("orientation must be horizontal or vertical")
 
     # Remove spines.
-    ax.spines['right'].set_visible(False)
-    ax.spines['top'].set_visible(False)
+    ax.spines["right"].set_visible(False)
+    ax.spines["top"].set_visible(False)
 
     ax.set_title(title, fontsize=title_size)
     plt.tight_layout()
@@ -145,25 +158,27 @@ def plot(explanation,
         return
 
 
-def comparison_plot(comparison_explanations,
-                    comparison_names=None,
-                    feature_names=None,
-                    sort_features=True,
-                    max_features=np.inf,
-                    orientation='vertical',
-                    error_bars=True,
-                    confidence_level=0.95,
-                    capsize=5,
-                    colors=('tab:green', 'tab:blue'),
-                    title='Feature Importance Comparison',
-                    title_size=20,
-                    tick_size=16,
-                    tick_rotation=None,
-                    label_size=16,
-                    legend_loc=None,
-                    figsize=(10, 7),
-                    return_fig=False):
-    '''
+def comparison_plot(
+    comparison_explanations,
+    comparison_names=None,
+    feature_names=None,
+    sort_features=True,
+    max_features=np.inf,
+    orientation="vertical",
+    error_bars=True,
+    confidence_level=0.95,
+    capsize=5,
+    colors=("tab:green", "tab:blue"),
+    title="Feature Importance Comparison",
+    title_size=20,
+    tick_size=16,
+    tick_rotation=None,
+    label_size=16,
+    legend_loc=None,
+    figsize=(10, 7),
+    return_fig=False,
+):
+    """
     Plot comparison between two different Explanation objects.
 
     Args:
@@ -185,34 +200,36 @@ def comparison_plot(comparison_explanations,
       legend_loc: legend location.
       figsize: figure size (if fig is None).
       return_fig: whether to return matplotlib figure object.
-    '''
+    """
     # Default feature names.
     if feature_names is None:
-        feature_names = ['Feature {}'.format(i) for i in
-                         range(len(comparison_explanations[0].values))]
+        feature_names = [
+            f"Feature {i}" for i in range(len(comparison_explanations[0].values))
+        ]
     if isinstance(feature_names, list):
         feature_names = np.array(feature_names)
 
     # Default comparison names.
     num_comps = len(comparison_explanations)
     if num_comps not in (2, 3, 4, 5):
-        raise ValueError('only support comparisons for 2-5 explanations')
+        raise ValueError("only support comparisons for 2-5 explanations")
     if comparison_names is None:
-        comparison_names = ['Explanation {}'.format(i) for i in
-                            range(num_comps)]
+        comparison_names = [f"Explanation {i}" for i in range(num_comps)]
 
     # Default colors.
     if colors is None:
-        colors = ['tab:green', 'tab:blue', 'tab:purple',
-                  'tab:orange', 'tab:pink'][:num_comps]
+        colors = ["tab:green", "tab:blue", "tab:purple", "tab:orange", "tab:pink"][
+            :num_comps
+        ]
 
     # Determine explanation type.
-    unique_types = np.unique([explanation.explanation_type
-                              for explanation in comparison_explanations])
+    unique_types = np.unique([
+        explanation.explanation_type for explanation in comparison_explanations
+    ])
     if len(unique_types) == 1:
         explanation_type = unique_types[0]
     else:
-        explanation_type = 'Importance'
+        explanation_type = "Importance"
 
     # Sort features if necessary.
     if len(feature_names) > max_features:
@@ -231,85 +248,105 @@ def comparison_plot(comparison_explanations,
 
     # Remove extra features if necessary.
     if len(feature_names) > max_features:
-        feature_names = (list(feature_names[:max_features])
-                         + ['Remaining Features'])
+        feature_names = [*list(feature_names[:max_features]), "Remaining Features"]
         values = [
-            list(sage_values[:max_features])
-            + [np.sum(sage_values[max_features:])]
-            for sage_values in values]
-        std = [list(stddev[:max_features])
-               + [np.sum(stddev[max_features:] ** 2) ** 0.5]
-               for stddev in std]
+            [*list(sage_values[:max_features]), np.sum(sage_values[max_features:])]
+            for sage_values in values
+        ]
+        std = [
+            [*list(stddev[:max_features]), np.sum(stddev[max_features:] ** 2) ** 0.5]
+            for stddev in std
+        ]
 
     # Warn if too many features.
     if len(feature_names) > 50:
-        warnings.warn('Plotting {} features may make figure too crowded, '
-                      'consider using max_features'.format(
-                        len(feature_names)), Warning)
+        warnings.warn(
+            "Plotting {} features may make figure too crowded, "
+            "consider using max_features".format(len(feature_names)),
+            Warning,
+        )
 
     # Discard std if necessary.
     if not error_bars:
         std = [None for _ in std]
     else:
         assert 0 < confidence_level < 1
-        std = [np.array(stddev) * norm.ppf(0.5 + confidence_level / 2) for stddev in std]
+        std = [
+            np.array(stddev) * norm.ppf(0.5 + confidence_level / 2) for stddev in std
+        ]
 
     # Make plot.
     width = 0.8 / num_comps
     fig = plt.figure(figsize=figsize)
     ax = fig.gca()
 
-    if orientation == 'horizontal':
+    if orientation == "horizontal":
         # Bar chart.
         enumeration = enumerate(zip(values, std, comparison_names, colors))
         for i, (sage_values, stddev, name, color) in enumeration:
-            pos = - 0.4 + width / 2 + width * i
-            ax.barh(np.arange(len(feature_names))[::-1] - pos,
-                    sage_values, height=width, color=color, xerr=stddev,
-                    capsize=capsize, label=name)
+            pos = -0.4 + width / 2 + width * i
+            ax.barh(
+                np.arange(len(feature_names))[::-1] - pos,
+                sage_values,
+                height=width,
+                color=color,
+                xerr=stddev,
+                capsize=capsize,
+                label=name,
+            )
 
         # Feature labels.
         if tick_rotation is not None:
-            raise ValueError('rotation not supported for horizontal charts')
+            raise ValueError("rotation not supported for horizontal charts")
         ax.set_yticks(np.arange(len(feature_names))[::-1])
         ax.set_yticklabels(feature_names, fontsize=label_size)
 
         # Axis labels and ticks.
-        ax.set_ylabel('')
-        ax.set_xlabel('{} value'.format(explanation_type), fontsize=label_size)
-        ax.tick_params(axis='x', labelsize=tick_size)
+        ax.set_ylabel("")
+        ax.set_xlabel(f"{explanation_type} value", fontsize=label_size)
+        ax.tick_params(axis="x", labelsize=tick_size)
 
-    elif orientation == 'vertical':
+    elif orientation == "vertical":
         # Bar chart.
         enumeration = enumerate(zip(values, std, comparison_names, colors))
         for i, (sage_values, stddev, name, color) in enumeration:
-            pos = - 0.4 + width / 2 + width * i
-            ax.bar(np.arange(len(feature_names)) + pos,
-                   sage_values, width=width, color=color, yerr=stddev,
-                   capsize=capsize, label=name)
+            pos = -0.4 + width / 2 + width * i
+            ax.bar(
+                np.arange(len(feature_names)) + pos,
+                sage_values,
+                width=width,
+                color=color,
+                yerr=stddev,
+                capsize=capsize,
+                label=name,
+            )
 
         # Feature labels.
         if tick_rotation is None:
             tick_rotation = 45
         if tick_rotation < 90:
-            ha = 'right'
-            rotation_mode = 'anchor'
+            ha = "right"
+            rotation_mode = "anchor"
         else:
-            ha = 'center'
-            rotation_mode = 'default'
+            ha = "center"
+            rotation_mode = "default"
         ax.set_xticks(np.arange(len(feature_names)))
-        ax.set_xticklabels(feature_names, rotation=tick_rotation, ha=ha,
-                           rotation_mode=rotation_mode,
-                           fontsize=label_size)
+        ax.set_xticklabels(
+            feature_names,
+            rotation=tick_rotation,
+            ha=ha,
+            rotation_mode=rotation_mode,
+            fontsize=label_size,
+        )
 
         # Axis labels and ticks.
-        ax.set_ylabel('{} value'.format(explanation_type), fontsize=label_size)
-        ax.set_xlabel('')
-        ax.tick_params(axis='y', labelsize=tick_size)
+        ax.set_ylabel(f"{explanation_type} value", fontsize=label_size)
+        ax.set_xlabel("")
+        ax.tick_params(axis="y", labelsize=tick_size)
 
     # Remove spines.
-    ax.spines['right'].set_visible(False)
-    ax.spines['top'].set_visible(False)
+    ax.spines["right"].set_visible(False)
+    ax.spines["top"].set_visible(False)
 
     plt.legend(loc=legend_loc, fontsize=label_size)
     ax.set_title(title, fontsize=title_size)
@@ -321,21 +358,23 @@ def comparison_plot(comparison_explanations,
         return
 
 
-def plot_sign(explanation,
-              feature_names,
-              sort_features=True,
-              max_features=np.inf,
-              orientation='horizontal',
-              confidence_level=0.95,
-              capsize=5,
-              title='Feature Importance Sign',
-              title_size=20,
-              tick_size=16,
-              tick_rotation=None,
-              label_size=16,
-              figsize=(10, 7),
-              return_fig=False):
-    '''
+def plot_sign(
+    explanation,
+    feature_names,
+    sort_features=True,
+    max_features=np.inf,
+    orientation="horizontal",
+    confidence_level=0.95,
+    capsize=5,
+    title="Feature Importance Sign",
+    title_size=20,
+    tick_size=16,
+    tick_rotation=None,
+    label_size=16,
+    figsize=(10, 7),
+    return_fig=False,
+):
+    """
     Plot SAGE values, focusing on their sign.
 
     Args:
@@ -353,11 +392,10 @@ def plot_sign(explanation,
       label_size: font size for label.
       figsize: figure size (if fig is None).
       return_fig: whether to return matplotlib figure object.
-    '''
+    """
     # Default feature names.
     if feature_names is None:
-        feature_names = ['Feature {}'.format(i) for i in
-                         range(len(explanation.values))]
+        feature_names = [f"Feature {i}" for i in range(len(explanation.values))]
     if isinstance(feature_names, list):
         feature_names = np.array(feature_names)
 
@@ -371,11 +409,11 @@ def plot_sign(explanation,
     colors = []
     for val, width in zip(values, std):
         if val > 0 and val - width > 0:
-            colors.append('tab:green')
+            colors.append("tab:green")
         elif val < 0 and val + width < 0:
-            colors.append('tab:red')
+            colors.append("tab:red")
         else:
-            colors.append('tab:blue')
+            colors.append("tab:blue")
     colors = np.array(colors)
 
     # Sort features if necessary.
@@ -394,11 +432,13 @@ def plot_sign(explanation,
         # Keep highest magnitude features.
         new_value = np.sum(values[max_features:])
         new_std = np.sum(std[max_features:] ** 2) ** 0.5
-        values = np.array(list(values[:max_features]) + [new_value])
-        std = np.array(list(std[:max_features]) + [new_std])
-        colors = np.array(list(colors[:max_features]) + ['tab:purple'])
-        feature_names = np.array(list(feature_names[:max_features])
-                                 + ['Remaining Features'])
+        values = np.array([*list(values[:max_features]), new_value])
+        std = np.array([*list(std[:max_features]), new_std])
+        colors = np.array([*list(colors[:max_features]), "tab:purple"])
+        feature_names = np.array([
+            *list(feature_names[:max_features]),
+            "Remaining Features",
+        ])
 
     # Perform sorting.
     if sort_features:
@@ -410,70 +450,96 @@ def plot_sign(explanation,
 
     # Warn if too many features.
     if len(feature_names) > 50:
-        warnings.warn('Plotting {} features may make figure too crowded, '
-                      'consider using max_features'.format(
-                        len(feature_names)), Warning)
+        warnings.warn(
+            "Plotting {} features may make figure too crowded, "
+            "consider using max_features".format(len(feature_names)),
+            Warning,
+        )
 
     # Make plot.
     fig = plt.figure(figsize=figsize)
     ax = fig.gca()
 
-    if orientation == 'horizontal':
+    if orientation == "horizontal":
         # Bar chart.
-        ax.barh(np.arange(len(feature_names))[::-1], std,
-                left=values - std, color=colors, edgecolor='black',
-                linewidth=0.5)
-        ax.barh(np.arange(len(feature_names))[::-1], std,
-                left=values, color=colors, edgecolor='black',
-                linewidth=0.5)
-        ax.axvline(0, color='black', linewidth=0.5)
+        ax.barh(
+            np.arange(len(feature_names))[::-1],
+            std,
+            left=values - std,
+            color=colors,
+            edgecolor="black",
+            linewidth=0.5,
+        )
+        ax.barh(
+            np.arange(len(feature_names))[::-1],
+            std,
+            left=values,
+            color=colors,
+            edgecolor="black",
+            linewidth=0.5,
+        )
+        ax.axvline(0, color="black", linewidth=0.5)
 
         # Feature labels.
         if tick_rotation is not None:
-            raise ValueError('rotation not supported for horizontal charts')
+            raise ValueError("rotation not supported for horizontal charts")
         ax.set_yticks(np.arange(len(feature_names))[::-1])
         ax.set_yticklabels(feature_names, fontsize=label_size)
 
         # Axis labels and ticks.
-        ax.set_ylabel('')
-        ax.set_xlabel('{} value'.format(explanation.explanation_type),
-                      fontsize=label_size)
-        ax.tick_params(axis='x', labelsize=tick_size)
+        ax.set_ylabel("")
+        ax.set_xlabel(f"{explanation.explanation_type} value", fontsize=label_size)
+        ax.tick_params(axis="x", labelsize=tick_size)
 
-    elif orientation == 'vertical':
+    elif orientation == "vertical":
         # Bar chart.
-        ax.bar(np.arange(len(feature_names)), std, bottom=values - std,
-               color=colors, edgecolor='black', linewidth=0.5)
-        ax.bar(np.arange(len(feature_names)), std, bottom=values,
-               color=colors, edgecolor='black', linewidth=0.5)
-        ax.axhline(0, color='black', linewidth=0.5)
+        ax.bar(
+            np.arange(len(feature_names)),
+            std,
+            bottom=values - std,
+            color=colors,
+            edgecolor="black",
+            linewidth=0.5,
+        )
+        ax.bar(
+            np.arange(len(feature_names)),
+            std,
+            bottom=values,
+            color=colors,
+            edgecolor="black",
+            linewidth=0.5,
+        )
+        ax.axhline(0, color="black", linewidth=0.5)
 
         # Feature labels.
         if tick_rotation is None:
             tick_rotation = 45
         if tick_rotation < 90:
-            ha = 'right'
-            rotation_mode = 'anchor'
+            ha = "right"
+            rotation_mode = "anchor"
         else:
-            ha = 'center'
-            rotation_mode = 'default'
+            ha = "center"
+            rotation_mode = "default"
         ax.set_xticks(np.arange(len(feature_names)))
-        ax.set_xticklabels(feature_names, rotation=tick_rotation, ha=ha,
-                           rotation_mode=rotation_mode,
-                           fontsize=label_size)
+        ax.set_xticklabels(
+            feature_names,
+            rotation=tick_rotation,
+            ha=ha,
+            rotation_mode=rotation_mode,
+            fontsize=label_size,
+        )
 
         # Axis labels and ticks.
-        ax.set_ylabel('{} value'.format(explanation.explanation_type),
-                      fontsize=label_size)
-        ax.set_xlabel('')
-        ax.tick_params(axis='y', labelsize=tick_size)
+        ax.set_ylabel(f"{explanation.explanation_type} value", fontsize=label_size)
+        ax.set_xlabel("")
+        ax.tick_params(axis="y", labelsize=tick_size)
 
     else:
-        raise ValueError('orientation must be horizontal or vertical')
+        raise ValueError("orientation must be horizontal or vertical")
 
     # Remove spines.
-    ax.spines['right'].set_visible(False)
-    ax.spines['top'].set_visible(False)
+    ax.spines["right"].set_visible(False)
+    ax.spines["top"].set_visible(False)
 
     ax.set_title(title, fontsize=title_size)
     plt.tight_layout()

--- a/sage/utils.py
+++ b/sage/utils.py
@@ -1,44 +1,52 @@
 import sys
+
 import numpy as np
 
 
-
 def model_conversion(model):
-    '''Convert model to callable.'''
-    if safe_isinstance(model, 'sklearn.base.ClassifierMixin'):
+    """Convert model to callable."""
+    if safe_isinstance(model, "sklearn.base.ClassifierMixin"):
         return lambda x: model.predict_proba(x)
 
-    elif safe_isinstance(model, 'sklearn.base.RegressorMixin'):
+    elif safe_isinstance(model, "sklearn.base.RegressorMixin"):
         return lambda x: model.predict(x)
 
-    elif safe_isinstance(model, 'catboost.CatBoostClassifier'):
+    elif safe_isinstance(model, "catboost.CatBoostClassifier"):
         return lambda x: model.predict_proba(x)
 
-    elif safe_isinstance(model, 'catboost.CatBoostRegressor'):
+    elif safe_isinstance(model, "catboost.CatBoostRegressor") or safe_isinstance(
+        model, "lightgbm.basic.Booster"
+    ):
         return lambda x: model.predict(x)
 
-    elif safe_isinstance(model, 'lightgbm.basic.Booster'):
-        return lambda x: model.predict(x)
-
-    elif safe_isinstance(model, 'xgboost.core.Booster'):
+    elif safe_isinstance(model, "xgboost.core.Booster"):
         import xgboost
+
         return lambda x: model.predict(xgboost.DMatrix(x))
 
-    elif safe_isinstance(model, 'torch.nn.Module'):
-        print('Setting up imputer for PyTorch model, assuming that any '
-              'necessary output activations are applied properly. If '
-              'not, please set up nn.Sequential with nn.Sigmoid or nn.Softmax')
+    elif safe_isinstance(model, "torch.nn.Module"):
+        print(
+            "Setting up imputer for PyTorch model, assuming that any "
+            "necessary output activations are applied properly. If "
+            "not, please set up nn.Sequential with nn.Sigmoid or nn.Softmax"
+        )
 
         import torch
+
         model.eval()
         device = next(model.parameters()).device
-        return lambda x: model(torch.tensor(
-            x, dtype=torch.float32, device=device)).cpu().data.numpy()
+        return (
+            lambda x: model(torch.tensor(x, dtype=torch.float32, device=device))
+            .cpu()
+            .data.numpy()
+        )
 
-    elif safe_isinstance(model, 'keras.Model'):
-        print('Setting up imputer for keras model, assuming that any '
-              'necessary output activations are applied properly. If not, '
-              'please set up keras.Sequential with keras.layers.Softmax()')
+    elif safe_isinstance(model, "keras.Model"):
+        print(
+            "Setting up imputer for keras model, assuming that any "
+            "necessary output activations are applied properly. If not, "
+            "please set up keras.Sequential with keras.layers.Softmax()"
+        )
 
         return lambda x: model(x, training=False).numpy()
 
@@ -47,25 +55,27 @@ def model_conversion(model):
         return model
 
     else:
-        raise ValueError('model cannot be converted automatically, '
-                         'please convert to a lambda function')
+        raise ValueError(
+            "model cannot be converted automatically, "
+            "please convert to a lambda function"
+        )
 
 
 def dataset_output(imputer, X, batch_size):
-    '''Get model output for entire dataset.'''
+    """Get model output for entire dataset."""
     Y = []
     for i in range(int(np.ceil(len(X) / batch_size))):
-        x = X[i*batch_size:(i+1)*batch_size]
+        x = X[i * batch_size : (i + 1) * batch_size]
         pred = imputer(x, np.ones((len(x), imputer.num_groups), dtype=bool))
         Y.append(pred)
     return np.concatenate(Y)
 
 
 def verify_model_data(imputer, X, Y, loss, batch_size):
-    '''Ensure that model and data are set up properly.'''
+    """Ensure that model and data are set up properly."""
     check_labels = True
     if Y is None:
-        print('Calculating model sensitivity (Shapley Effects, not SAGE)')
+        print("Calculating model sensitivity (Shapley Effects, not SAGE)")
         check_labels = False
         Y = dataset_output(imputer, X, batch_size)
 
@@ -89,9 +99,10 @@ def verify_model_data(imputer, X, Y, loss, batch_size):
             elif Y.shape == (len(X), 1):
                 Y = Y[:, 0]
             else:
-                raise ValueError('labels shape should be (batch,) or (batch, 1)'
-                                 ' for cross entropy loss')
-
+                raise ValueError(
+                    "labels shape should be (batch,) or (batch, 1)"
+                    " for cross entropy loss"
+                )
 
         if (probs.ndim == 1) or (probs.shape[1] == 1):
             # Check label encoding.
@@ -105,8 +116,9 @@ def verify_model_data(imputer, X, Y, loss, batch_size):
                     Y = Y.copy()
                     Y[Y == -1] = 0
                 else:
-                    raise ValueError('labels for binary classification must be '
-                                     '[0, 1] or [-1, 1]')
+                    raise ValueError(
+                        "labels for binary classification must be " "[0, 1] or [-1, 1]"
+                    )
 
             # Check for valid probability outputs.
             valid_probs = np.all(np.logical_and(probs >= 0, probs <= 1))
@@ -118,23 +130,24 @@ def verify_model_data(imputer, X, Y, loss, batch_size):
             valid_probs = valid_probs and np.allclose(ones, np.ones(ones.shape))
 
         else:
-            raise ValueError('prediction has too many dimensions')
+            raise ValueError("prediction has too many dimensions")
 
         if not valid_probs:
-            raise ValueError('predictions are not valid probabilities')
+            raise ValueError("predictions are not valid probabilities")
 
     return X, Y
 
 
 class ImportanceTracker:
-    '''For tracking feature importance using a dynamic average.'''
+    """For tracking feature importance using a dynamic average."""
+
     def __init__(self):
         self.mean = 0
         self.sum_squares = 0
         self.N = 0
 
     def update(self, scores, num_samples=None):
-        '''
+        """
         Update mean and sum of squares using Welford's algorithm.
 
         Args:
@@ -142,7 +155,7 @@ class ImportanceTracker:
           num_samples: array of size (dim,) representing the number of samples
             for each dimension. For sparse updates, with void samples
             represented by zeros.
-        '''
+        """
         if num_samples is None:
             # Welford's algorithm.
             self.N += len(scores)
@@ -157,13 +170,13 @@ class ImportanceTracker:
             num_void = len(scores) - num_samples
             orig_mean = np.copy(self.mean)
             diff = scores - self.mean
-            self.mean += (
-                np.sum(diff, axis=0) +
-                self.mean * num_void) / np.maximum(self.N, 1)
+            self.mean += (np.sum(diff, axis=0) + self.mean * num_void) / np.maximum(
+                self.N, 1
+            )
             diff2 = scores - self.mean
             self.sum_squares += (
-                np.sum(diff * diff2, axis=0) -
-                orig_mean * self.mean * num_void)
+                np.sum(diff * diff2, axis=0) - orig_mean * self.mean * num_void
+            )
 
     @property
     def values(self):
@@ -176,13 +189,14 @@ class ImportanceTracker:
 
     @property
     def std(self):
-        return self.var ** 0.5
+        return self.var**0.5
 
 
 class MSELoss:
-    '''MSE loss that sums over non-batch dimensions.'''
-    def __init__(self, reduction='mean'):
-        assert reduction in ('none', 'mean')
+    """MSE loss that sums over non-batch dimensions."""
+
+    def __init__(self, reduction="mean"):
+        assert reduction in ("none", "mean")
         self.reduction = reduction
 
     def __call__(self, pred, target):
@@ -191,25 +205,26 @@ class MSELoss:
             pred = np.expand_dims(pred, -1)
         elif pred.shape[-1] == 1 and len(pred.shape) - len(target.shape) == 1:
             target = np.expand_dims(target, -1)
-        elif not target.shape == pred.shape:
-            raise ValueError('shape mismatch, pred has shape {} and target '
-                             'has shape {}'.format(pred.shape, target.shape))
-        loss = np.sum(
-            np.reshape((pred - target) ** 2, (len(pred), -1)), axis=1)
-        if self.reduction == 'mean':
+        elif target.shape != pred.shape:
+            raise ValueError(
+                f"shape mismatch, pred has shape {pred.shape} and target "
+                f"has shape {target.shape}"
+            )
+        loss = np.sum(np.reshape((pred - target) ** 2, (len(pred), -1)), axis=1)
+        if self.reduction == "mean":
             return np.mean(loss)
         else:
             return loss
 
-class ZeroOneLoss:
-    '''zero-one loss that expects probabilities.'''
 
-    def __init__(self, reduction='mean'):
-        assert reduction in ('none', 'mean')
+class ZeroOneLoss:
+    """zero-one loss that expects probabilities."""
+
+    def __init__(self, reduction="mean"):
+        assert reduction in ("none", "mean")
         self.reduction = reduction
 
     def __call__(self, pred, target):
-
         # Add a dimension to prediction probabilities if necessary.
         if pred.ndim == 1:
             pred = pred[:, np.newaxis]
@@ -223,16 +238,18 @@ class ZeroOneLoss:
             # Probabilistic labels.
             loss = (np.argmax(pred, axis=1) != np.argmax(target, axis=1)).astype(float)
         else:
-            raise ValueError('incorrect labels shape for zero-one loss')
+            raise ValueError("incorrect labels shape for zero-one loss")
 
-        if self.reduction == 'mean':
+        if self.reduction == "mean":
             return np.mean(loss)
         return loss
 
+
 class CrossEntropyLoss:
-    '''Cross entropy loss that expects probabilities.'''
-    def __init__(self, reduction='mean'):
-        assert reduction in ('none', 'mean')
+    """Cross entropy loss that expects probabilities."""
+
+    def __init__(self, reduction="mean"):
+        assert reduction in ("none", "mean")
         self.reduction = reduction
 
     def __call__(self, pred, target, eps=1e-12):
@@ -248,52 +265,52 @@ class CrossEntropyLoss:
         # Calculate loss.
         if target.ndim == 1:
             # Class labels.
-            loss = - np.log(pred[np.arange(len(pred)), target])
+            loss = -np.log(pred[np.arange(len(pred)), target])
         elif target.ndim == 2:
             # Probabilistic labels.
-            loss = - np.sum(target * np.log(pred), axis=1)
+            loss = -np.sum(target * np.log(pred), axis=1)
         else:
-            raise ValueError('incorrect labels shape for cross entropy loss')
+            raise ValueError("incorrect labels shape for cross entropy loss")
 
-        if self.reduction == 'mean':
+        if self.reduction == "mean":
             return np.mean(loss)
         else:
             return loss
 
 
-def get_loss(loss, reduction='mean'):
-    '''Get loss function by name.'''
-    if loss == 'cross entropy':
+def get_loss(loss, reduction="mean"):
+    """Get loss function by name."""
+    if loss == "cross entropy":
         loss_fn = CrossEntropyLoss(reduction=reduction)
-    elif loss == 'mse':
+    elif loss == "mse":
         loss_fn = MSELoss(reduction=reduction)
     else:
-        raise ValueError('unsupported loss: {}'.format(loss))
+        raise ValueError(f"unsupported loss: {loss}")
     return loss_fn
 
 
 def sample_subset_feature(input_size, n, ind):
-    '''
+    """
     Sample a subset of features where a given feature index must not be
     included. This helper function is used for estimating Shapley values, so
     the subset is sampled by 1) sampling the number of features to be included
     from a uniform distribution, and 2) sampling the features to be included.
-    '''
+    """
     S = np.zeros((n, input_size), dtype=bool)
     choices = list(range(input_size))
     del choices[ind]
+    rng = np.random.default_rng(seed=42)
     for row in S:
-        inds = np.random.choice(
-            choices, size=np.random.choice(input_size), replace=False)
+        inds = rng.choice(choices, size=rng.choice(input_size), replace=False)
         row[inds] = 1
     return S
 
 
 def safe_isinstance(obj, class_str):
-    '''Check isinstance without requiring imports.'''
+    """Check isinstance without requiring imports."""
     if not isinstance(class_str, str):
         return False
-    module_name, class_name = class_str.rsplit('.', 1)
+    module_name, class_name = class_str.rsplit(".", 1)
     if module_name not in sys.modules:
         return False
     module = sys.modules[module_name]


### PR DESCRIPTION
This PR adds basic support for linting/formatting based on [ruff](https://docs.astral.sh/), as discussed in #23 .

A minimal rule set (see `pyproject.toml`) is appied to keep diff in PR small. More rules can be added from https://beta.ruff.rs/docs/rules/. Currently, `I` isort is used for sorting imports, pep8-naming `N` for naming conventions, `NPY` for Numpy best practices, and `RUF` for ruff-specific rules. You can also ignore rules, either in the `pyproject.toml`, as done for all lower-case variable names, which contradicts matrix naming conventions or on the code level e.g., `# noqa: N802`, as done in `kernel_estimator.py` for function_names due to the same reason.

We should verify that the changes from refactoring / update of numpy random number generation, didn't break anything. Will keep this as WIP until I've performed some tests 🤓

@iancovert Do you want additional rules / different configurations?